### PR TITLE
Fix reproduction form validation

### DIFF
--- a/app/Http/Controllers/ReproductionController.php
+++ b/app/Http/Controllers/ReproductionController.php
@@ -31,12 +31,17 @@ class ReproductionController extends Controller
     public function store(Request $request)
     {
         // Validação básica; é interessante adicionar regras específicas para cada tipo
-        $data = $request->validate([
+        $rules = [
             'type' => 'required|string|in:monta_natural,inseminacao,transferencia,confirmacao_prenhes',
-            'date' => 'required|date',
-            // Outras validações podem ser adicionadas conforme o tipo de reprodução
-        ]);
+        ];
 
+        // Somente alguns tipos exigem a data principal
+        if ($request->input('type') !== 'confirmacao_prenhes') {
+            $rules['date'] = 'required|date';
+        }
+
+        $data = $request->validate($rules);
+        
         // Atribui o usuário autenticado
         $data['user_id'] = $request->user()->id;
 


### PR DESCRIPTION
## Summary
- allow reproduction confirmation without a general date

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407b930e2c8328b5755d7134eeb827