### PR TITLE
Add sex field to animals

### DIFF
--- a/app/Http/Controllers/AnimalController.php
+++ b/app/Http/Controllers/AnimalController.php
@@ -39,6 +39,7 @@ class AnimalController extends Controller
         $data = $request->validate([
             'name'       => 'required|string|max:255',
             'breed_id'   => 'required|exists:breeds,id',
+            'sex'        => 'required|in:male,female',
             'birth_date' => 'nullable|date',
             'father'     => 'nullable|string|max:255',
             'mother'     => 'nullable|string|max:255',

--- a/app/Models/Animal.php
+++ b/app/Models/Animal.php
@@ -10,7 +10,15 @@ class Animal extends Model
     use HasFactory;
 
     protected $fillable = [
-        'user_id', 'name', 'breed_id', 'birth_date', 'father', 'mother', 'progeny', 'photos'
+        'user_id',
+        'name',
+        'breed_id',
+        'sex',
+        'birth_date',
+        'father',
+        'mother',
+        'progeny',
+        'photos',
     ];
 
     protected $casts = [

--- a/database/migrations/2025_06_05_000000_add_sex_to_animals_table.php
+++ b/database/migrations/2025_06_05_000000_add_sex_to_animals_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table('animals', function (Blueprint $table) {
+            $table->enum('sex', ['male', 'female'])->default('female')->after('breed_id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('animals', function (Blueprint $table) {
+            $table->dropColumn('sex');
+        });
+    }
+};

--- a/resources/js/Pages/Animals/Create.jsx
+++ b/resources/js/Pages/Animals/Create.jsx
@@ -6,6 +6,7 @@ export default function Create({ breeds }) {
     const { data, setData, post, processing, errors } = useForm({
         name: '',
         breed_id: '',
+        sex: 'female',
         birth_date: '',
         father: '',
         mother: '',
@@ -30,6 +31,7 @@ export default function Create({ breeds }) {
         const formData = new FormData();
         formData.append('name', data.name);
         formData.append('breed_id', data.breed_id);
+        formData.append('sex', data.sex);
         formData.append('birth_date', data.birth_date);
         formData.append('father', data.father);
         formData.append('mother', data.mother);
@@ -72,21 +74,34 @@ export default function Create({ breeds }) {
                         </div>
 
                         <div className="mb-4">
-                            <label className="block text-gray-700">Raça</label>
-                            <select
-                                value={data.breed_id}
-                                onChange={e => setData('breed_id', e.target.value)}
-                                className="mt-1 block w-full border rounded p-2 focus:ring focus:ring-indigo-300"
-                            >
-                                <option value="">Selecione a raça</option>
-                                {breeds.map(breed => (
-                                    <option key={breed.id} value={breed.id}>
-                                        {breed.name}
-                                    </option>
-                                ))}
-                            </select>
-                            {errors.breed_id && <div className="text-red-500 text-sm mt-1">{errors.breed_id}</div>}
-                        </div>
+                        <label className="block text-gray-700">Raça</label>
+                        <select
+                            value={data.breed_id}
+                            onChange={e => setData('breed_id', e.target.value)}
+                            className="mt-1 block w-full border rounded p-2 focus:ring focus:ring-indigo-300"
+                        >
+                            <option value="">Selecione a raça</option>
+                            {breeds.map(breed => (
+                                <option key={breed.id} value={breed.id}>
+                                    {breed.name}
+                                </option>
+                            ))}
+                        </select>
+                        {errors.breed_id && <div className="text-red-500 text-sm mt-1">{errors.breed_id}</div>}
+                    </div>
+
+                    <div className="mb-4">
+                        <label className="block text-gray-700">Sexo</label>
+                        <select
+                            value={data.sex}
+                            onChange={e => setData('sex', e.target.value)}
+                            className="mt-1 block w-full border rounded p-2 focus:ring focus:ring-indigo-300"
+                        >
+                            <option value="female">Fêmea</option>
+                            <option value="male">Macho</option>
+                        </select>
+                        {errors.sex && <div className="text-red-500 text-sm mt-1">{errors.sex}</div>}
+                    </div>
 
                         <div className="mb-4">
                             <label className="block text-gray-700">Data de Nascimento</label>

--- a/resources/js/Pages/Animals/Show.jsx
+++ b/resources/js/Pages/Animals/Show.jsx
@@ -24,6 +24,9 @@ export default function Show({ animal, treatments = [], reproductionActivities =
                             <strong>Raça:</strong> {animal.breed.name}
                         </p>
                         <p>
+                            <strong>Sexo:</strong> {animal.sex === 'male' ? 'Macho' : 'Fêmea'}
+                        </p>
+                        <p>
                             <strong>Data de Nascimento:</strong>{' '}
                             {new Date(animal.birth_date).toLocaleDateString()}
                         </p>

--- a/resources/js/Pages/Reproduction.jsx
+++ b/resources/js/Pages/Reproduction.jsx
@@ -212,11 +212,13 @@ export default function Reproduction({ animals, reproductions }) {
                                         className="mt-1 block w-full border rounded p-2"
                                     >
                                         <option value="">Selecione</option>
-                                        {animals.map((animal) => (
-                                            <option key={animal.id} value={animal.id}>
-                                                {animal.name}
-                                            </option>
-                                        ))}
+                                        {animals
+                                            .filter((animal) => animal.sex === 'female')
+                                            .map((animal) => (
+                                                <option key={animal.id} value={animal.id}>
+                                                    {animal.name}
+                                                </option>
+                                            ))}
                                     </select>
                                 ) : (
                                     <input
@@ -248,11 +250,13 @@ export default function Reproduction({ animals, reproductions }) {
                                         className="mt-1 block w-full border rounded p-2"
                                     >
                                         <option value="">Selecione</option>
-                                        {animals.map((animal) => (
-                                            <option key={animal.id} value={animal.id}>
-                                                {animal.name}
-                                            </option>
-                                        ))}
+                                        {animals
+                                            .filter((animal) => animal.sex === 'male')
+                                            .map((animal) => (
+                                                <option key={animal.id} value={animal.id}>
+                                                    {animal.name}
+                                                </option>
+                                            ))}
                                     </select>
                                 ) : (
                                     <input
@@ -287,11 +291,13 @@ export default function Reproduction({ animals, reproductions }) {
                                         className="mt-1 block w-full border rounded p-2"
                                     >
                                         <option value="">Selecione</option>
-                                        {animals.map((animal) => (
-                                            <option key={animal.id} value={animal.id}>
-                                                {animal.name}
-                                            </option>
-                                        ))}
+                                        {animals
+                                            .filter((animal) => animal.sex === 'female')
+                                            .map((animal) => (
+                                                <option key={animal.id} value={animal.id}>
+                                                    {animal.name}
+                                                </option>
+                                            ))}
                                     </select>
                                 ) : (
                                     <input
@@ -321,11 +327,13 @@ export default function Reproduction({ animals, reproductions }) {
                                         className="mt-1 block w-full border rounded p-2"
                                     >
                                         <option value="">Selecione</option>
-                                        {animals.map((animal) => (
-                                            <option key={animal.id} value={animal.id}>
-                                                {animal.name}
-                                            </option>
-                                        ))}
+                                        {animals
+                                            .filter((animal) => animal.sex === 'male')
+                                            .map((animal) => (
+                                                <option key={animal.id} value={animal.id}>
+                                                    {animal.name}
+                                                </option>
+                                            ))}
                                     </select>
                                 ) : (
                                     <input
@@ -355,11 +363,13 @@ export default function Reproduction({ animals, reproductions }) {
                                         className="mt-1 block w-full border rounded p-2"
                                     >
                                         <option value="">Selecione</option>
-                                        {animals.map((animal) => (
-                                            <option key={animal.id} value={animal.id}>
-                                                {animal.name}
-                                            </option>
-                                        ))}
+                                        {animals
+                                            .filter((animal) => animal.sex === 'female')
+                                            .map((animal) => (
+                                                <option key={animal.id} value={animal.id}>
+                                                    {animal.name}
+                                                </option>
+                                            ))}
                                     </select>
                                 ) : (
                                     <input
@@ -404,11 +414,13 @@ export default function Reproduction({ animals, reproductions }) {
                                         className="mt-1 block w-full border rounded p-2"
                                     >
                                         <option value="">Selecione</option>
-                                        {animals.map((animal) => (
-                                            <option key={animal.id} value={animal.id}>
-                                                {animal.name}
-                                            </option>
-                                        ))}
+                                        {animals
+                                            .filter((animal) => animal.sex === 'male')
+                                            .map((animal) => (
+                                                <option key={animal.id} value={animal.id}>
+                                                    {animal.name}
+                                                </option>
+                                            ))}
                                     </select>
                                 ) : (
                                     <input


### PR DESCRIPTION
## Summary
- add `sex` column to animals table
- include `sex` in Animal model and controller validation
- allow choosing animal sex in creation form and display it on show page
- filter animal selections by sex on reproduction form

## Testing
- `php artisan test` *(fails: php not available)*
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684080e3ef2883289317014ba3dc8b75