### PR TITLE
Add seeders for animals, treatments and reproductions

### DIFF
--- a/database/seeders/AnimalSeeder.php
+++ b/database/seeders/AnimalSeeder.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Animal;
+use App\Models\Breed;
+use App\Models\User;
+use Carbon\Carbon;
+
+class AnimalSeeder extends Seeder
+{
+    public function run()
+    {
+        $user = User::first();
+        if (! $user) {
+            return;
+        }
+
+        $breeds = Breed::take(3)->get();
+        if ($breeds->isEmpty()) {
+            return;
+        }
+
+        Animal::create([
+            'user_id' => $user->id,
+            'name' => 'Thor',
+            'breed_id' => $breeds[0]->id,
+            'sex' => 'male',
+            'birth_date' => Carbon::now()->subYears(5),
+        ]);
+
+        Animal::create([
+            'user_id' => $user->id,
+            'name' => 'Lua',
+            'breed_id' => $breeds->get(1)->id ?? $breeds[0]->id,
+            'sex' => 'female',
+            'birth_date' => Carbon::now()->subYears(4),
+        ]);
+
+        Animal::create([
+            'user_id' => $user->id,
+            'name' => 'Estrela',
+            'breed_id' => $breeds->get(2)->id ?? $breeds[0]->id,
+            'sex' => 'female',
+            'birth_date' => Carbon::now()->subYears(3),
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,9 @@ class DatabaseSeeder extends Seeder
             AssociationSeeder::class,
             ReproductionTypeSeeder::class,
             TreatmentTypeSeeder::class,
+            AnimalSeeder::class,
+            TreatmentSeeder::class,
+            ReproductionSeeder::class,
         ]);
     }
 }

--- a/database/seeders/ReproductionSeeder.php
+++ b/database/seeders/ReproductionSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Reproduction;
+use App\Models\Animal;
+use App\Models\User;
+use Carbon\Carbon;
+
+class ReproductionSeeder extends Seeder
+{
+    public function run()
+    {
+        $user = User::first();
+        $animals = Animal::take(2)->get();
+        if (! $user || $animals->count() < 2) {
+            return;
+        }
+
+        Reproduction::create([
+            'user_id' => $user->id,
+            'type' => 'monta_natural',
+            'date' => Carbon::now()->subDays(30),
+            'egua_id' => $animals[1]->id,
+            'cavalo_id' => $animals[0]->id,
+        ]);
+
+        Reproduction::create([
+            'user_id' => $user->id,
+            'type' => 'confirmacao_prenhes',
+            'date_exame' => Carbon::now()->subDays(5),
+            'date_provavel' => Carbon::now()->addMonths(7),
+            'animal_id' => $animals[1]->id,
+            'pai_id' => $animals[0]->id,
+        ]);
+    }
+}

--- a/database/seeders/TreatmentSeeder.php
+++ b/database/seeders/TreatmentSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Treatment;
+use App\Models\TreatmentType;
+use App\Models\Animal;
+use App\Models\User;
+use Carbon\Carbon;
+
+class TreatmentSeeder extends Seeder
+{
+    public function run()
+    {
+        $user = User::first();
+        $animal = Animal::first();
+        if (! $user || ! $animal) {
+            return;
+        }
+
+        $vacina = TreatmentType::where('name', 'Vacina')->first();
+        $casqueamento = TreatmentType::where('name', 'Casqueamento')->first();
+
+        Treatment::create([
+            'user_id' => $user->id,
+            'animal_id' => $animal->id,
+            'treatment_type_id' => optional($vacina)->id,
+            'date' => Carbon::now()->subDays(10),
+            'details' => ['type' => 'V8'],
+        ]);
+
+        Treatment::create([
+            'user_id' => $user->id,
+            'animal_id' => $animal->id,
+            'treatment_type_id' => optional($casqueamento)->id,
+            'date' => Carbon::now()->subDays(5),
+            'details' => [],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add seeders to populate example animals
- add seeders for treatments and reproductions tied to the first user
- run new seeders from `DatabaseSeeder`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68408e4546388328983c3f6ac5dfd683