### PR TITLE
Add awards management for animals

### DIFF
--- a/app/Http/Controllers/AnimalController.php
+++ b/app/Http/Controllers/AnimalController.php
@@ -6,6 +6,7 @@ use App\Models\Animal;
 use App\Models\Breed;
 use App\Models\Treatment;
 use App\Models\Reproduction;
+use App\Models\Award;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 
@@ -81,12 +82,14 @@ class AnimalController extends Controller
             })
             ->get();
 
-            $treatments = Treatment::with('treatmentType')->where('animal_id', $animal->id)->get();
+        $treatments = Treatment::with('treatmentType')->where('animal_id', $animal->id)->get();
+        $awards = Award::where('animal_id', $animal->id)->orderByDesc('date')->get();
 
         return Inertia::render('Animals/Show', [
             'animal' => $animal,
             'treatments' => $treatments,
             'reproductionActivities' => $reproductionActivities,
+            'awards' => $awards,
         ]);
     }
 

--- a/app/Http/Controllers/AwardController.php
+++ b/app/Http/Controllers/AwardController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Award;
+use App\Models\Animal;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class AwardController extends Controller
+{
+    public function store(Request $request, Animal $animal)
+    {
+        $this->authorize('update', $animal);
+
+        $data = $request->validate([
+            'competition' => 'required|string|max:255',
+            'position' => 'nullable|string|max:255',
+            'date' => 'nullable|date',
+        ]);
+
+        $data['animal_id'] = $animal->id;
+        Award::create($data);
+
+        return redirect()->route('animals.show', $animal);
+    }
+}

--- a/app/Models/Animal.php
+++ b/app/Models/Animal.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\Award;
 
 class Animal extends Model
 {
@@ -34,5 +35,10 @@ class Animal extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function awards()
+    {
+        return $this->hasMany(Award::class);
     }
 }

--- a/app/Models/Award.php
+++ b/app/Models/Award.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Award extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'animal_id',
+        'competition',
+        'position',
+        'date',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+    ];
+
+    public function animal()
+    {
+        return $this->belongsTo(Animal::class);
+    }
+}

--- a/database/migrations/2025_06_06_000000_create_awards_table.php
+++ b/database/migrations/2025_06_06_000000_create_awards_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('awards', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('animal_id')->constrained()->onDelete('cascade');
+            $table->string('competition');
+            $table->string('position')->nullable();
+            $table->date('date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('awards');
+    }
+};

--- a/resources/js/Pages/Animals/Show.jsx
+++ b/resources/js/Pages/Animals/Show.jsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { Head, Link } from '@inertiajs/react';
+import { Head, Link, router } from '@inertiajs/react';
 import Modal from '@/Components/Modal';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 
-export default function Show({ animal, treatments = [], reproductionActivities = [] }) {
+export default function Show({ animal, treatments = [], reproductionActivities = [], awards = [] }) {
     const [showProcedures, setShowProcedures] = useState(false);
     const [showReproductions, setShowReproductions] = useState(false);
+    const [showAwards, setShowAwards] = useState(false);
 
     return (
         <AuthenticatedLayout
@@ -69,6 +70,12 @@ export default function Show({ animal, treatments = [], reproductionActivities =
                             className="flex-1 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors duration-200"
                         >
                             Reproduções
+                        </button>
+                        <button
+                            onClick={() => setShowAwards(true)}
+                            className="flex-1 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 transition-colors duration-200"
+                        >
+                            Premiações
                         </button>
                         <Link
                             href={route('animals.edit', animal.id)}
@@ -183,6 +190,53 @@ export default function Show({ animal, treatments = [], reproductionActivities =
                                 Fechar
                             </button>
                         </div>
+                    </div>
+                </Modal>
+
+                {/* Modal para premiações */}
+                <Modal show={showAwards} onClose={() => setShowAwards(false)}>
+                    <div className="p-4">
+                        <h2 className="text-xl font-semibold mb-4">Premiações de {animal.name}</h2>
+                        {awards && awards.length > 0 ? (
+                            <div className="space-y-4 max-h-96 overflow-y-auto">
+                                {awards.map((award) => (
+                                    <div key={award.id} className="border rounded p-4 flex items-center space-x-2">
+                                        <span role="img" aria-label="trophy">🏆</span>
+                                        <div className="flex-1">
+                                            <p className="font-semibold">{award.competition}</p>
+                                            {award.position && <p className="text-sm">{award.position}</p>}
+                                            {award.date && (
+                                                <p className="text-xs text-gray-500">
+                                                    {new Date(award.date).toLocaleDateString()}
+                                                </p>
+                                            )}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <p>Não há premiações cadastradas para este animal.</p>
+                        )}
+                        <form
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                const formData = new FormData(e.target);
+                                router.post(route('awards.store', animal.id), formData);
+                            }}
+                            className="mt-4 space-y-2"
+                        >
+                            <input type="text" name="competition" placeholder="Competição" className="w-full border rounded p-2" required />
+                            <input type="text" name="position" placeholder="Colocação" className="w-full border rounded p-2" />
+                            <input type="date" name="date" className="w-full border rounded p-2" />
+                            <div className="flex justify-end space-x-2">
+                                <button type="button" onClick={() => setShowAwards(false)} className="py-2 px-4 bg-gray-500 text-white rounded hover:bg-gray-600 transition-colors duration-200">
+                                    Fechar
+                                </button>
+                                <button type="submit" className="py-2 px-4 bg-green-600 text-white rounded hover:bg-green-700 transition-colors duration-200">
+                                    Salvar
+                                </button>
+                            </div>
+                        </form>
                     </div>
                 </Modal>
             </main>

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,8 @@ Route::middleware(['auth'])->group(function () {
 
     Route::get('/notifications', [\App\Http\Controllers\NotificationController::class, 'index'])->name('notifications.index');
     Route::post('/notifications/read', [\App\Http\Controllers\NotificationController::class, 'markAllRead'])->name('notifications.read');
+
+    Route::post('/animals/{animal}/awards', [\App\Http\Controllers\AwardController::class, 'store'])->name('awards.store');
 });
 
 // Rotas de autenticação (login, registro, etc.)


### PR DESCRIPTION
## Summary
- allow animals to have many awards
- store awards with new migration, model and controller
- fetch and display awards in animal detail page
- provide mobile friendly modal to manage awards
- add route for saving awards

## Testing
- `npm run build`
- `vendor/bin/phpunit --stop-on-failure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840925612548328acab876f7ca1364d