### PR TITLE
Update dashboard to show module cards

### DIFF
--- a/resources/js/Components/OptionCard.jsx
+++ b/resources/js/Components/OptionCard.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Link } from '@inertiajs/react';
+
+export default function OptionCard({ href, icon: Icon, children }) {
+    return (
+        <Link href={href} className="bg-white rounded-lg shadow flex flex-col items-center justify-center p-4 hover:bg-gray-100" >
+            <Icon className="h-8 w-8 text-brand-600" />
+            <span className="mt-2 text-sm font-semibold text-gray-700 text-center">{children}</span>
+        </Link>
+    );
+}

--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -1,14 +1,9 @@
-import Header from './Header';
-import Footer from './Footer';
-
-export default function AuthenticatedLayout({ header, children }) {
+export default function AuthenticatedLayout({ children }) {
     return (
         <div className="min-h-screen bg-gray-200 flex flex-col">
-            <Header />
-            <main className="flex-1 pt-20 pb-16">
+            <main className="flex-1 flex flex-col">
                 {children}
             </main>
-            <Footer />
         </div>
     );
 }

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -1,35 +1,72 @@
 import React from 'react';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import Container from '@/Components/Container';
-import AnimalsCarousel from '@/Components/AnimalsCarousel';
-import FinanceChart from '@/Components/FinanceChart';
+import OptionCard from '@/Components/OptionCard';
 import { Head } from '@inertiajs/react';
 
-export default function Dashboard({ animals, finance }) {
+const PlusCircleIcon = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>
+        <path fillRule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zM12.75 9a.75.75 0 00-1.5 0v2.25H9a.75.75 0 000 1.5h2.25V15a.75.75 0 001.5 0v-2.25H15a.75.75 0 000-1.5h-2.25V9z" clipRule="evenodd" />
+    </svg>
+);
+
+const HeartIcon = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>
+        <path d="M11.645 20.91l-.007-.003-.022-.012a15.247 15.247 0 01-.383-.218 25.18 25.18 0 01-4.244-3.17C4.688 15.36 2.25 12.174 2.25 8.25 2.25 5.322 4.714 3 7.688 3A5.5 5.5 0 0112 5.052 5.5 5.5 0 0116.313 3c2.973 0 5.437 2.322 5.437 5.25 0 3.925-2.438 7.111-4.739 9.256a25.175 25.175 0 01-4.244 3.17 15.247 15.247 0 01-.383.219l-.022.012-.007.004-.003.001a.752.752 0 01-.704 0l-.003-.001z" />
+    </svg>
+);
+
+const SparklesIcon = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>
+        <path fillRule="evenodd" d="M9 4.5a.75.75 0 01.721.544l.813 2.846a3.75 3.75 0 002.576 2.576l2.846.813a.75.75 0 010 1.442l-2.846.813a3.75 3.75 0 00-2.576 2.576l-.813 2.846a.75.75 0 01-1.442 0l-.813-2.846a3.75 3.75 0 00-2.576-2.576l-2.846-.813a.75.75 0 010-1.442l2.846-.813A3.75 3.75 0 007.466 7.89l.813-2.846A.75.75 0 019 4.5zM18 1.5a.75.75 0 01.728.568l.258 1.036c.236.94.97 1.674 1.91 1.91l1.036.258a.75.75 0 010 1.456l-1.036.258c-.94.236-1.674.97-1.91 1.91l-.258 1.036a.75.75 0 01-1.456 0l-.258-1.036a2.625 2.625 0 00-1.91-1.91l-1.036-.258a.75.75 0 010-1.456l1.036-.258a2.625 2.625 0 001.91-1.91l.258-1.036A.75.75 0 0118 1.5zM16.5 15a.75.75 0 01.712.513l.394 1.183c.15.447.5.799.948.948l1.183.395a.75.75 0 010 1.422l-1.183.395c-.447.15-.799.5-.948.948l-.395 1.183a.75.75 0 01-1.422 0l-.395-1.183a1.5 1.5 0 00-.948-.948l-1.183-.395a.75.75 0 010-1.422l1.183-.395c.447-.15.799-.5.948-.948l.395-1.183A.75.75 0 0116.5 15z" clipRule="evenodd" />
+    </svg>
+);
+
+const DollarIcon = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>
+        <path d="M10.464 8.746c.227-.18.497-.311.786-.394v2.795a2.252 2.252 0 01-.786-.393c-.394-.313-.546-.681-.546-1.004 0-.323.152-.691.546-1.004zM12.75 15.662v-2.824c.347.085.664.228.921.421.427.32.579.686.579.991 0 .305-.152.671-.579.991a2.534 2.534 0 01-.921.42z" />
+        <path fillRule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zM12.75 6a.75.75 0 00-1.5 0v.816a3.836 3.836 0 00-1.72.756c-.712.566-1.112 1.35-1.112 2.178 0 .829.4 1.612 1.113 2.178.502.4 1.102.647 1.719.756v2.978a2.536 2.536 0 01-.921-.421l-.879-.66a.75.75 0 00-.9 1.2l.879.66c.533.4 1.169.645 1.821.75V18a.75.75 0 001.5 0v-.81a4.124 4.124 0 001.821-.749c.745-.559 1.179-1.344 1.179-2.191 0-.847-.434-1.632-1.179-2.191a4.122 4.122 0 00-1.821-.75V8.354c.29.082.559.213.786.393l.415.33a.75.75 0 00.933-1.175l-.415-.33a3.836 3.836 0 00-1.719-.755V6z" clipRule="evenodd" />
+    </svg>
+);
+
+const BellIcon = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>
+        <path fillRule="evenodd" d="M5.25 9a6.75 6.75 0 0113.5 0v.75c0 2.123.8 4.057 2.118 5.52a.75.75 0 01-.297 1.206c-1.544.57-3.16.99-4.831 1.243a3.75 3.75 0 11-7.48 0 24.585 24.585 0 01-4.831-1.244.75.75 0 01-.298-1.205A8.217 8.217 0 005.25 9.75V9zm4.502 8.9a2.25 2.25 0 104.496 0 25.057 25.057 0 01-4.496 0z" clipRule="evenodd" />
+    </svg>
+);
+
+const UserIcon = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" {...props}>
+        <path fillRule="evenodd" d="M7.5 6a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM3.751 20.105a8.25 8.25 0 0116.498 0 .75.75 0 01-.437.695A18.683 18.683 0 0112 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 01-.437-.695z" clipRule="evenodd" />
+    </svg>
+);
+
+export default function Dashboard() {
     return (
-        <AuthenticatedLayout
-            header={
-                <header className="flex flex-col md:flex-row justify-between items-center p-4 border-b border-gray-200">
-                    <h2 className="text-xl font-semibold text-gray-800">
-                        Dashboard
-                    </h2>
-                    <img
-                        src="/handhorse.png"
-                        alt="Logo da Handhorse"
-                        className="h-10 w-auto mt-2 md:mt-0"
-                        loading="lazy"
-                    />
-                </header>
-            }
-        >
+        <AuthenticatedLayout>
             <Head title="Dashboard" />
-            <main className="flex-1 overflow-y-auto bg-gray-100">
-                <Container className="p-4">
-                    {/* Conteúdo centralizado e responsivo */}
-                    <AnimalsCarousel animals={animals} />
-                    <FinanceChart data={finance} />
-                </Container>
-            </main>
+            <div className="min-h-screen flex flex-col items-center justify-center p-6 space-y-6">
+                <img src="/handhorse.png" alt="Handhorse Logo" className="h-20" />
+                <div className="grid grid-cols-2 gap-4 w-full max-w-md">
+                    <OptionCard href={route('animals.create')} icon={PlusCircleIcon}>
+                        Cadastrar Animal
+                    </OptionCard>
+                    <OptionCard href={route('animal-health')} icon={HeartIcon}>
+                        Saúde Animal
+                    </OptionCard>
+                    <OptionCard href={route('reproduction.index')} icon={SparklesIcon}>
+                        Reprodução
+                    </OptionCard>
+                    <OptionCard href={route('finance.index')} icon={DollarIcon}>
+                        Financeiro
+                    </OptionCard>
+                    <OptionCard href={route('notifications.index')} icon={BellIcon}>
+                        Notificações
+                    </OptionCard>
+                    <OptionCard href={route('profile.edit')} icon={UserIcon}>
+                        Perfil
+                    </OptionCard>
+                </div>
+            </div>
         </AuthenticatedLayout>
     );
 }


### PR DESCRIPTION
## Summary
- redesign `AuthenticatedLayout` to remove the navigation menu
- add new `OptionCard` component for dashboard shortcuts
- rebuild the dashboard with a grid of option cards

## Testing
- `npm run build`
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b520ba6883288c75c86ad44479e6