### PR TITLE
Include animal name in association reminders

### DIFF
--- a/app/Http/Controllers/ReproductionController.php
+++ b/app/Http/Controllers/ReproductionController.php
@@ -109,8 +109,9 @@ class ReproductionController extends Controller
 
         $animalId = $reproduction->egua_id ?? $reproduction->doadora_id ?? $reproduction->animal_id;
         if ($animalId) {
-            $breed = Animal::find($animalId)?->breed;
-            if ($breed && $breed->association) {
+            $animal = Animal::find($animalId);
+            $breed = $animal?->breed;
+            if ($animal && $breed && $breed->association) {
                 $deadline = $breed->association->deadlines()->where('procedure', 'cobricao')->first();
                 $eventDate = $reproduction->date ?? $reproduction->date_exame;
                 if ($deadline && $deadline->days && $eventDate) {
@@ -122,7 +123,8 @@ class ReproductionController extends Controller
                                 $request->user(),
                                 $breed,
                                 $deadline,
-                                $before
+                                $before,
+                                $animal->name
                             )->delay($sendAt);
                         }
                     }

--- a/app/Jobs/SendAssociationReminder.php
+++ b/app/Jobs/SendAssociationReminder.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Models\Breed;
 use App\Models\User;
+use App\Models\Animal;
 use App\Models\AssociationDeadline;
 use App\Notifications\AssociationReminder;
 use Illuminate\Bus\Queueable;
@@ -20,13 +21,15 @@ class SendAssociationReminder implements ShouldQueue
     protected Breed $breed;
     protected AssociationDeadline $deadline;
     protected int $daysLeft;
+    protected string $animalName;
 
-    public function __construct(User $user, Breed $breed, AssociationDeadline $deadline, int $daysLeft)
+    public function __construct(User $user, Breed $breed, AssociationDeadline $deadline, int $daysLeft, string $animalName)
     {
         $this->user = $user;
         $this->breed = $breed;
         $this->deadline = $deadline;
         $this->daysLeft = $daysLeft;
+        $this->animalName = $animalName;
     }
 
     public function handle(): void
@@ -34,7 +37,8 @@ class SendAssociationReminder implements ShouldQueue
         $this->user->notify(new AssociationReminder(
             $this->breed,
             $this->deadline,
-            $this->daysLeft
+            $this->daysLeft,
+            $this->animalName
         ));
     }
 }

--- a/app/Notifications/AssociationReminder.php
+++ b/app/Notifications/AssociationReminder.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use App\Models\Breed;
+use App\Models\Animal;
 use App\Models\AssociationDeadline;
 
 class AssociationReminder extends Notification implements ShouldQueue
@@ -16,12 +17,14 @@ class AssociationReminder extends Notification implements ShouldQueue
     protected Breed $breed;
     protected AssociationDeadline $deadline;
     protected int $daysLeft;
+    protected string $animalName;
 
-    public function __construct(Breed $breed, AssociationDeadline $deadline, int $daysLeft)
+    public function __construct(Breed $breed, AssociationDeadline $deadline, int $daysLeft, string $animalName)
     {
         $this->breed = $breed;
         $this->deadline = $deadline;
         $this->daysLeft = $daysLeft;
+        $this->animalName = $animalName;
     }
 
     public function via(object $notifiable): array
@@ -33,14 +36,14 @@ class AssociationReminder extends Notification implements ShouldQueue
     {
         return (new MailMessage)
             ->subject('Lembrete de comunicação à associação')
-            ->line('Faltam '.$this->daysLeft.' dia(s) para comunicar '.$this->deadline->procedure.' à associação '.$this->breed->association->name.'.')
+            ->line('Faltam '.$this->daysLeft.' dia(s) para comunicar '.$this->deadline->procedure.' do animal '.$this->animalName.' à associação '.$this->breed->association->name.'.')
             ->line('Regra: '.$this->deadline->rule);
     }
 
     public function toArray(object $notifiable): array
     {
         return [
-            'message' => 'Faltam '.$this->daysLeft.' dia(s) para comunicar '.$this->deadline->procedure.' à associação '.$this->breed->association->name.'.',
+            'message' => 'Faltam '.$this->daysLeft.' dia(s) para comunicar '.$this->deadline->procedure.' do animal '.$this->animalName.' à associação '.$this->breed->association->name.'.',
             'rule' => $this->deadline->rule,
         ];
     }

--- a/database/seeders/ReminderSeeder.php
+++ b/database/seeders/ReminderSeeder.php
@@ -3,8 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\User;
-use App\Models\Breed;
-use App\Models\AssociationDeadline;
+use App\Models\Animal;
 use App\Notifications\AssociationReminder;
 use Illuminate\Database\Seeder;
 
@@ -17,15 +16,19 @@ class ReminderSeeder extends Seeder
             return;
         }
 
-        $breeds = Breed::with('association.deadlines')->has('association')->get();
-        foreach ($breeds as $breed) {
+        $animals = Animal::with('breed.association.deadlines')
+            ->whereHas('breed.association')
+            ->get();
+
+        foreach ($animals as $animal) {
+            $breed = $animal->breed;
             $deadline = $breed->association->deadlines->first();
             if (! $deadline) {
                 continue;
             }
 
             foreach ([30, 15, 1] as $daysLeft) {
-                $user->notify(new AssociationReminder($breed, $deadline, $daysLeft));
+                $user->notify(new AssociationReminder($breed, $deadline, $daysLeft, $animal->name));
             }
         }
     }


### PR DESCRIPTION
## Summary
- include animal name parameter in `AssociationReminder`
- send the animal's name through `SendAssociationReminder`
- pass animal name from `ReproductionController`
- generate seeded reminders for each animal with their name

## Testing
- `php -v` *(fails: command not found)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b5ad30bc8328840e7988fe833983