### PR TITLE
Add reminders/fines info section

### DIFF
--- a/resources/js/Pages/Notifications.jsx
+++ b/resources/js/Pages/Notifications.jsx
@@ -42,6 +42,37 @@ export default function Notifications({ notifications }) {
                 ) : (
                     <p>Nenhuma notificação.</p>
                 )}
+                <section className="bg-white p-4 rounded shadow space-y-2">
+                    <h3 className="text-lg font-semibold">Informações sobre Lembretes e Multas</h3>
+                    <p className="text-sm">
+                        Para manter o registro dos animais em dia, é importante respeitar os prazos de comunicação para cada tipo de notificação. O descumprimento desses prazos pode gerar multas conforme as regras de cada associação.
+                    </p>
+                    <ul className="list-disc pl-5 text-sm space-y-1">
+                        <li>Comunicação de cobrição</li>
+                        <li>Comunicação de nascimento</li>
+                        <li>Resenha do potro</li>
+                        <li>Comunicação de TE (transferência de embrião)</li>
+                    </ul>
+                    <div className="space-y-1 text-sm">
+                        <p className="font-semibold mt-4">Mangalarga Marchador (ABCCMM)</p>
+                        <p>Prazo de 120 dias para comunicar cobrição e nascimento sem multa. Após esse período, a multa é de R$ 300,00 por animal.</p>
+
+                        <p className="font-semibold mt-4">Mangalarga Paulista (ABCCRM)</p>
+                        <p>Comunicações devem ser enviadas semestralmente: eventos de janeiro a junho até 31/08 e de julho a dezembro até 28/02. A cada seis meses de atraso há multa de R$ 233,00.</p>
+
+                        <p className="font-semibold mt-4">Pônei (ABCC)</p>
+                        <p>Envio de cobrição até 30/04 ou em até 120 dias se controlada. Multa de R$ 50,00 por animal para notificações fora do prazo.</p>
+
+                        <p className="font-semibold mt-4">Pampa (ABCPAMPA)</p>
+                        <p>Comunicações do primeiro semestre até 31/07 e do segundo semestre até 31/01. Atrasos de até 30 dias geram multa de R$ 50,00; após esse período é exigido exame de DNA com verificação de parentesco (+R$ 250,00).</p>
+
+                        <p className="font-semibold mt-4">Pega (ABCJPEGA)</p>
+                        <p>Prazo de 120 dias sem multa. Acima desse período a multa é de R$ 40,00 por animal.</p>
+
+                        <p className="font-semibold mt-4">Crioulo (ABCCC)</p>
+                        <p>Comunicação de cobrição deve ocorrer até 30/06 da temporada. Multas variam a partir de R$ 227,00 para sócios e R$ 454,00 para não sócios. Para resenhas após nove meses do nascimento, a multa inicial é de R$ 304,00 e aumenta conforme a idade do animal.</p>
+                    </div>
+                </section>
             </div>
         </AuthenticatedLayout>
     );


### PR DESCRIPTION
## Summary
- include a new "Informações sobre Lembretes e Multas" section in notifications page

## Testing
- `npm run build`
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bc8f1c388328a0760fdafe0b0e25