### PR TITLE
Improve home header layout

### DIFF
--- a/resources/js/Components/ApplicationLogo.jsx
+++ b/resources/js/Components/ApplicationLogo.jsx
@@ -6,7 +6,7 @@ export default function ApplicationLogo(props) {
             {...props}
             src="/handhorse.png"
             alt="Handhorse Logo"
-            className="h-10 w-auto" // Ajuste o tamanho conforme necessário
+            className="h-16 w-auto" // Ajuste o tamanho conforme necessário
         />
     );
 }

--- a/resources/js/Pages/Welcome.jsx
+++ b/resources/js/Pages/Welcome.jsx
@@ -37,7 +37,7 @@ export default function Welcome({ auth, laravelVersion, phpVersion }) {
                                     />
                                 </svg>
                             </div>
-                            <nav className="-mx-3 flex flex-1 justify-end">
+                            <nav className="-mx-3 flex flex-1 justify-center">
                                 {auth.user ? (
                                     <Link
                                         href={route('dashboard')}


### PR DESCRIPTION
## Summary
- enlarge home page logo
- center the nav links on the welcome page

## Testing
- `npm run build`
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487036fe48832897a06abc8a48cc1a